### PR TITLE
[Sprint 2] dataset dataloader -> main

### DIFF
--- a/configs/contracts.py
+++ b/configs/contracts.py
@@ -196,7 +196,7 @@ class PredictionRecord(TypedDict):
 
 class EvalResult(TypedDict, total=False):
     """Dictionary returned by :meth:`evaluation.vqa_eval.VQAEvaluator.compute_accuracy`
-    and by :meth:`training.trainer.VQATrainer.evaluate`.
+    yes_no:  float
 
     ★ overall  : float  — Mean VQA accuracy over all questions (0.0 – 1.0 scale,
                            i.e. NOT percentage).

--- a/configs/contracts.py
+++ b/configs/contracts.py
@@ -1,0 +1,445 @@
+"""
+contracts.py — Unified I/O contracts for the BLIP-2 VQA experiment repo.
+
+PURPOSE
+-------
+This file is the single source of truth for every tensor shape, dictionary key,
+and type that crosses a module boundary.  Any code (model, dataset, trainer,
+evaluation) that produces or consumes structured data MUST conform to the
+TypedDicts and constants defined here.
+
+RULE: if you add a new key to a batch, a model output, or a prediction record,
+you add it here first, then implement it everywhere else.
+
+CONTENTS
+--------
+1.  Canonical key constants          – string literals re-used across modules.
+2.  Batch contract (DataLoader out)  – VQABatch
+3.  Model output contracts           – ModelOutput, GenerateOutput
+4.  Prediction record contract       – PredictionRecord
+5.  Evaluation output contract       – EvalResult
+6.  Checkpoint contract              – CheckpointDict
+7.  Config sub-contracts             – ModelConfig, DataConfig, TrainingConfig,
+                                       OptimizerConfig, SchedulerConfig, LoggingConfig
+8.  Fusion model contracts           – FusionInput, FusionOutput
+9.  Runtime constants                – ANSWER_VOCAB_SIZE, IMAGE_SIZE, …
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+# ---------------------------------------------------------------------------
+# mypy / runtime-safe TypedDict (works on Python 3.8+)
+# ---------------------------------------------------------------------------
+try:
+    from typing import TypedDict, Literal
+except ImportError:  # Python 3.7 fallback
+    from typing_extensions import TypedDict, Literal  # type: ignore[assignment]
+
+import torch
+
+# ===========================================================================
+# 1. Canonical key constants
+# ===========================================================================
+# Use these constants instead of bare string literals so that a typo becomes
+# a NameError instead of a silent bug.
+
+# ── Batch keys ──────────────────────────────────────────────────────────────
+KEY_PIXEL_VALUES    = "pixel_values"       # torch.Tensor [B, 3, H, W] float32
+KEY_IMAGE_FEATURES  = "image_features"     # torch.Tensor [B, N_tokens, CLIP_DIM] float32 (pre-extracted)
+KEY_INPUT_IDS       = "input_ids"          # torch.Tensor [B, L]       int64  (tokenized question)
+KEY_ATTENTION_MASK  = "attention_mask"     # torch.Tensor [B, L]       int64 0/1
+KEY_ANSWER_SCORES   = "answer_scores"      # torch.Tensor [B, V]       float32  ∈ [0,1]
+KEY_ANSWER_LABEL    = "answer_label"       # torch.Tensor [B]          int64  (hard label index, -1 = OOV)
+KEY_LABELS          = "labels"             # torch.Tensor [B, L]       int64   (-100 = ignore)
+KEY_QUESTION_IDS    = "question_ids"       # List[int]   — VQAv2 question_id for each sample
+KEY_QUESTION_TEXT   = "question_text"      # List[str]   — raw question strings
+KEY_IMAGE_IDS       = "image_ids"          # List[int]   — COCO image_id for each sample
+KEY_ANSWER_TEXT     = "answer"             # List[str]   — most common answer string (singular)
+KEY_ANSWERS         = "answers"            # List[List[str]] — all 10 raw answer strings
+KEY_ANSWER_TYPE     = "answer_type"        # List[str]   — "yes/no" | "number" | "other"
+
+# ── Model output keys ────────────────────────────────────────────────────────
+KEY_LOSS            = "loss"               # torch.Tensor scalar
+KEY_LOGITS          = "logits"             # torch.Tensor [B, V]       float32 (classify)
+                                           #           or [B, L, vocab] float32 (generate)
+KEY_VISUAL_FEATURES = "visual_features"    # torch.Tensor [B, D]       float32
+
+# ── Prediction / evaluation keys ────────────────────────────────────────────
+KEY_QUESTION_ID     = "question_id"        # int
+KEY_ANSWER          = "answer"             # str  (predicted answer string)
+
+# ── Checkpoint keys ─────────────────────────────────────────────────────────
+KEY_EPOCH           = "epoch"              # int
+KEY_GLOBAL_STEP     = "global_step"        # int
+KEY_MODEL_STATE     = "model_state_dict"   # OrderedDict
+KEY_OPTIM_STATE     = "optimizer_state_dict"
+KEY_SCHED_STATE     = "scheduler_state_dict"
+KEY_BEST_VAL_METRIC = "best_val_metric"    # float
+KEY_CONFIG          = "config"             # dict (full YAML config)
+
+# ── Evaluation result keys ───────────────────────────────────────────────────
+KEY_OVERALL_ACC     = "overall"            # float  VQA accuracy 0-1
+KEY_YESNO_ACC       = "yes/no"             # float
+KEY_NUMBER_ACC      = "number"             # float
+KEY_OTHER_ACC       = "other"              # float
+
+
+# ===========================================================================
+# 2. Batch contract  (output of DataLoader / VQADataset.__getitem__)
+# ===========================================================================
+
+class VQABatch(TypedDict, total=False):
+    """Structured batch produced by :class:`data.vqa_dataset.VQADataset`.
+
+    Mandatory fields (``total=False`` so optional fields don't break older
+    code, but the fields below marked ★ are always present):
+
+    ★ pixel_values   : torch.Tensor  shape [B, 3, IMAGE_SIZE, IMAGE_SIZE], float32
+                       Pre-processed image tensor (normalized with ImageNet stats).
+    ★ input_ids      : torch.Tensor  shape [B, MAX_QUESTION_LENGTH], int64
+                       Tokenised question padded / truncated to MAX_QUESTION_LENGTH.
+    ★ attention_mask : torch.Tensor  shape [B, MAX_QUESTION_LENGTH], int64, values {0, 1}
+                       0 = padding, 1 = real token.
+    ★ question_ids   : List[int]     length B
+                       VQAv2 question_id for each sample.
+      question_text  : List[str]     length B
+                       Raw question strings (present in eval mode).
+      image_ids      : List[int]     length B
+                       COCO image_id for each sample.
+      answer_scores  : torch.Tensor  shape [B, ANSWER_VOCAB_SIZE], float32 ∈ [0, 1]
+                       Soft answer scores: min(human_count / 3, 1.0).
+                       Only present when annotation file is provided (train / val).
+      labels         : torch.Tensor  shape [B, MAX_QUESTION_LENGTH], int64
+                       Token ids for teacher-forcing; positions to ignore = -100.
+                       Only present in generative training.
+    """
+
+    # ── Image (exactly one of the two will be present per batch) ──────────────
+    pixel_values:   torch.Tensor    # [B, 3, IMAGE_SIZE, IMAGE_SIZE]   when use_cache=False
+    image_features: torch.Tensor    # [B, CLIP_PATCH_TOKENS, CLIP_DIM] when use_cache=True
+    # ── Question ────────────────────────────────────────────────────────────────
+    input_ids:      torch.Tensor    # [B, MAX_QUESTION_LENGTH]  tokenized
+    attention_mask: torch.Tensor    # [B, MAX_QUESTION_LENGTH]
+    question_ids:   List[int]       # VQAv2 question_id
+    question_text:  List[str]       # raw question strings
+    image_ids:      List[int]       # COCO image_id
+    # ── Answer (absent on test split) ───────────────────────────────────────────
+    answer_scores:  torch.Tensor    # [B, ANSWER_VOCAB_SIZE]  soft targets ∈ [0,1]
+    answer_label:   torch.Tensor    # [B]  hard label index (-1 = OOV)
+    answer:         List            # List[str]  most common answer
+    answers:        List            # List[List[str]]  all 10 answers
+    answer_type:    List            # List[str]  "yes/no"|"number"|"other"
+    labels:         torch.Tensor    # [B, L]  for generative training only
+
+
+# ===========================================================================
+# 3. Model output contracts
+# ===========================================================================
+
+class ModelOutput(TypedDict, total=False):
+    """Dictionary returned by :meth:`models.blip2_vqa.BLIP2VQA.forward`.
+
+    Mode "classify"
+    ---------------
+    ★ logits          : torch.Tensor  [B, ANSWER_VOCAB_SIZE], float32 (raw logits)
+      loss            : torch.Tensor  scalar  (only when answer_scores provided)
+      visual_features : torch.Tensor  [B, HIDDEN_SIZE], float32  (Q-Former mean pool)
+
+    Mode "generate"
+    ---------------
+    ★ logits          : torch.Tensor  [B, SEQ_LEN, LM_VOCAB_SIZE], float32
+      loss            : torch.Tensor  scalar  (only when labels provided)
+
+    ★ = always present in that mode.
+    """
+
+    loss:            torch.Tensor
+    logits:          torch.Tensor
+    visual_features: torch.Tensor
+
+
+class GenerateOutput(TypedDict):
+    """Return type of :meth:`models.blip2_vqa.BLIP2VQA.generate_answers`.
+
+    Produced per-batch; the caller should collect and flatten over batches.
+
+    question_ids : List[int]  — VQAv2 question ids (same order as input)
+    answers      : List[str]  — decoded answer strings (post-processed, lowercased)
+    """
+
+    question_ids: List[int]
+    answers:      List[str]
+
+
+# ===========================================================================
+# 4. Prediction record  (one element in the predictions list)
+# ===========================================================================
+
+class PredictionRecord(TypedDict):
+    """One prediction entry passed to :meth:`evaluation.vqa_eval.VQAEvaluator.compute_accuracy`.
+
+    question_id : int — VQAv2 question_id.
+    answer      : str — Predicted answer string.  Must be the *raw* model
+                        output before normalisation; :class:`VQAEvaluator`
+                        applies ``normalize_answer`` internally.
+    """
+
+    question_id: int
+    answer:      str
+
+
+# ===========================================================================
+# 5. Evaluation output contract
+# ===========================================================================
+
+class EvalResult(TypedDict, total=False):
+    """Dictionary returned by :meth:`evaluation.vqa_eval.VQAEvaluator.compute_accuracy`
+    and by :meth:`training.trainer.VQATrainer.evaluate`.
+
+    ★ overall  : float  — Mean VQA accuracy over all questions (0.0 – 1.0 scale,
+                           i.e. NOT percentage).
+      yes/no   : float  — Accuracy for yes/no question type.
+      number   : float  — Accuracy for number question type.
+      other    : float  — Accuracy for all other question types.
+      loss     : float  — Validation loss (average over batches).
+      metric   : float  — Primary scalar metric used for checkpoint selection;
+                           equals ``overall`` when available, else ``-loss``.
+    """
+
+    overall: float
+    yesno:   float
+    number:  float
+    other:   float
+    loss:    float
+    metric:  float
+
+
+# ===========================================================================
+# 6. Checkpoint contract
+# ===========================================================================
+
+class CheckpointDict(TypedDict, total=False):
+    """Schema for ``.pth`` checkpoint files saved by
+    :meth:`training.trainer.VQATrainer._save_checkpoint`.
+
+    ★ epoch                  : int
+    ★ global_step            : int
+    ★ model_state_dict       : dict  — output of ``model.state_dict()``
+    ★ optimizer_state_dict   : dict  — output of ``optimizer.state_dict()``
+    ★ best_val_metric        : float
+    ★ config                 : dict  — full YAML config dict
+      scheduler_state_dict   : dict  — output of ``scheduler.state_dict()``
+                                        (absent when no scheduler is used)
+    """
+
+    epoch:                 int
+    global_step:           int
+    model_state_dict:      dict
+    optimizer_state_dict:  dict
+    best_val_metric:       float
+    config:                dict
+    scheduler_state_dict:  dict
+
+
+# ===========================================================================
+# 7. Config sub-contracts  (mirrors default.yaml structure)
+# ===========================================================================
+
+class ModelConfig(TypedDict, total=False):
+    """``cfg["model"]`` block in default.yaml."""
+
+    name:               str    # "blip2_vqa" | "concat_fusion" | "bilinear_fusion"
+                               # | "attention_fusion" | "mlb_fusion"
+    blip2_model_name:   str    # HuggingFace model id, e.g. "Salesforce/blip2-opt-2.7b"
+    num_query_tokens:   int    # Q-Former query token count (default 32)
+    vision_width:       int    # ViT output dim (default 1408 for EVA-CLIP ViT-g)
+    hidden_size:        int    # Q-Former hidden dim (default 768)
+    num_layers:         int    # Q-Former transformer layers (default 12)
+    num_heads:          int    # Attention heads (default 12)
+    intermediate_size:  int    # FFN intermediate dim (default 3072)
+    dropout:            float  # Dropout probability (default 0.1)
+    max_answer_length:  int    # Max new tokens in generate mode (default 10)
+    fusion_output_size: int    # Hidden size for fusion baselines (default 1024)
+    num_answers:        int    # Answer vocab size (default 3129 for VQAv2)
+    mode:               str    # "generate" | "classify"
+
+
+class DataConfig(TypedDict, total=False):
+    """``cfg["data"]`` block.
+
+    Sprint-2 config-object interface (used by VQAv2Dataset / build_dataloader):
+        data_root / vqav2_dir / coco_dir / cache_dir compose all paths internally.
+
+    Legacy flat-path interface (kept for backward compatibility):
+        train_annotation, val_annotation, … are full paths.
+    """
+
+    # ── Sprint-2 config-object fields ───────────────────────────────────────────
+    data_root:           str   # root directory for all data sub-folders
+    vqav2_dir:           str   # sub-folder with VQAv2 JSON files (relative to data_root)
+    coco_dir:            str   # sub-folder with COCO images       (relative to data_root)
+    cache_dir:           str   # sub-folder for HDF5 feature cache (relative to data_root)
+    train_size:          int   # number of training samples after stratified subset
+    val_size:            int   # number of validation samples after stratified subset
+    seed:                int   # random seed for stratified sampling
+    batch_size:          int   # batch size used by build_dataloader
+    # ── Shared ──────────────────────────────────────────────────────────────────
+    answer_list:         str   # optional path to pre-built answer vocab JSON
+    max_question_length: int   # token truncation length (default 50)
+    image_size:          int   # resize target (default 224)
+    num_workers:         int   # DataLoader worker processes (default 4)
+    # ── Legacy flat-path fields (backward compat) ───────────────────────────────
+    train_annotation:    str   # full path to v2_OpenEnded_mscoco_train2014_questions.json
+    val_annotation:      str   # full path to v2_OpenEnded_mscoco_val2014_questions.json
+    train_answers:       str   # full path to v2_mscoco_train2014_annotations.json
+    val_answers:         str   # full path to v2_mscoco_val2014_annotations.json
+    train_image_dir:     str   # full path to train2014/ directory
+    val_image_dir:       str   # full path to val2014/ directory
+
+
+class TrainingConfig(TypedDict, total=False):
+    """``cfg["training"]`` block in default.yaml."""
+
+    output_dir:                   str    # checkpoint save directory
+    log_dir:                      str    # TensorBoard / WandB log directory
+    num_epochs:                   int
+    batch_size:                   int    # training batch size
+    eval_batch_size:              int    # validation batch size
+    learning_rate:                float
+    weight_decay:                 float
+    warmup_steps:                 int
+    gradient_clip:                float  # max-norm; 0 = disabled
+    gradient_accumulation_steps:  int
+    save_every:                   int    # save checkpoint every N epochs
+    eval_every:                   int    # evaluate every N epochs
+    seed:                         int
+    mixed_precision:              bool
+    resume_from:                  Optional[str]   # checkpoint path or null
+
+
+class OptimizerConfig(TypedDict, total=False):
+    """``cfg["optimizer"]`` block."""
+
+    name:  str    # "adamw" | "adam" | "sgd"
+    betas: List[float]
+    eps:   float
+
+
+class SchedulerConfig(TypedDict, total=False):
+    """``cfg["scheduler"]`` block."""
+
+    name:   str    # "cosine" | "linear" | "constant"
+    min_lr: float
+
+
+class LoggingConfig(TypedDict, total=False):
+    """``cfg["logging"]`` block."""
+
+    use_wandb:  bool
+    project:    str
+    run_name:   Optional[str]
+
+
+# ===========================================================================
+# 8. Fusion model contracts
+# ===========================================================================
+
+class FusionInput(TypedDict, total=False):
+    """Inputs to any fusion baseline forward() method.
+
+    ConcatFusion / BilinearFusion / MLBFusion
+    -----------------------------------------
+    ★ visual_features : torch.Tensor  [B, visual_dim]    – pooled visual rep.
+    ★ text_features   : torch.Tensor  [B, text_dim]      – pooled text rep.
+
+    AttentionFusion
+    ---------------
+    ★ visual_features : torch.Tensor  [B, N_tokens, visual_dim]
+    ★ text_features   : torch.Tensor  [B, text_dim]
+      visual_mask     : torch.Tensor  [B, N_tokens]  bool  True = keep
+    """
+
+    visual_features: torch.Tensor
+    text_features:   torch.Tensor
+    visual_mask:     torch.Tensor
+
+
+class FusionOutput(TypedDict):
+    """Return value of all fusion baseline forward() methods.
+
+    logits : torch.Tensor  [B, num_answers], float32  — raw (pre-softmax) logits.
+    """
+
+    logits: torch.Tensor
+
+
+# ===========================================================================
+# 9. Runtime constants
+# ===========================================================================
+
+# VQAv2 answer vocabulary size (3,129 most frequent answers in training set)
+ANSWER_VOCAB_SIZE: int = 3129
+
+# Default image resolution fed to the vision encoder
+IMAGE_SIZE: int = 224
+
+# Q-Former defaults (must match QFormerConfig defaults)
+NUM_QUERY_TOKENS: int = 32
+QFORMER_HIDDEN_SIZE: int = 768
+VISION_ENCODER_WIDTH: int = 1408   # EVA-CLIP ViT-g/14
+
+# CLIP ViT-L/14 feature dimensions (used by pre_extract_features.py)
+CLIP_FEATURE_DIM: int = 1024    # ViT-L/14 output channel dimension
+CLIP_PATCH_TOKENS: int = 257    # 1 CLS + 256 patch tokens at 224×224
+
+# Question tokenisation
+MAX_QUESTION_LENGTH: int = 50
+
+# Answer generation
+MAX_ANSWER_LENGTH: int = 10        # maximum new tokens in generate mode
+
+# VQA soft-score normalisation denominator
+VQA_SCORE_DENOMINATOR: int = 3     # min(count / 3, 1.0)
+
+# Padding / ignore index for labels tensor
+LABEL_IGNORE_INDEX: int = -100
+
+# Model name keys (must match ModelConfig.name values and fusion registry keys)
+MODEL_BLIP2_VQA:      str = "blip2_vqa"
+MODEL_CONCAT_FUSION:  str = "concat_fusion"
+MODEL_BILINEAR_FUSION: str = "bilinear_fusion"
+MODEL_ATTENTION_FUSION: str = "attention_fusion"
+MODEL_MLB_FUSION:     str = "mlb_fusion"
+
+VALID_MODEL_NAMES = frozenset({
+    MODEL_BLIP2_VQA,
+    MODEL_CONCAT_FUSION,
+    MODEL_BILINEAR_FUSION,
+    MODEL_ATTENTION_FUSION,
+    MODEL_MLB_FUSION,
+})
+
+# Operating modes for BLIP2VQA
+MODE_GENERATE: str = "generate"
+MODE_CLASSIFY: str = "classify"
+VALID_MODES = frozenset({MODE_GENERATE, MODE_CLASSIFY})
+
+# Loss types for VQALoss
+LOSS_BCE: str = "bce"
+LOSS_CE:  str = "ce"
+LOSS_KL:  str = "kl"
+VALID_LOSS_TYPES = frozenset({LOSS_BCE, LOSS_CE, LOSS_KL})
+
+# Optimizer names
+OPTIM_ADAMW: str = "adamw"
+OPTIM_ADAM:  str = "adam"
+OPTIM_SGD:   str = "sgd"
+VALID_OPTIMIZER_NAMES = frozenset({OPTIM_ADAMW, OPTIM_ADAM, OPTIM_SGD})
+
+# Scheduler names
+SCHED_COSINE:   str = "cosine"
+SCHED_LINEAR:   str = "linear"
+SCHED_CONSTANT: str = "constant"
+VALID_SCHEDULER_NAMES = frozenset({SCHED_COSINE, SCHED_LINEAR, SCHED_CONSTANT})

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,3 +1,21 @@
-from data.vqa_dataset import VQADataset, build_vqa_dataloader
+from data.vqa_dataset import (
+    VQAv2Dataset,
+    VQADataset,           # backward-compat alias
+    build_dataloader,
+    build_vqa_dataloader, # backward-compat alias
+    build_answer_vocab,
+    normalize_answer,
+    get_tokenizer,
+    collate_fn,
+)
 
-__all__ = ["VQADataset", "build_vqa_dataloader"]
+__all__ = [
+    "VQAv2Dataset",
+    "VQADataset",
+    "build_dataloader",
+    "build_vqa_dataloader",
+    "build_answer_vocab",
+    "normalize_answer",
+    "get_tokenizer",
+    "collate_fn",
+]

--- a/data/pre_extract_features.py
+++ b/data/pre_extract_features.py
@@ -1,0 +1,108 @@
+"""Pre-extract ViT-L/14 (CLIP) image features for all COCO 2014 images.
+Outputs: data/cache/train_features.h5 and val_features.h5
+         Key: str(image_id), Value: float16 array (257, 1024)
+Supports resume: skips image_ids already in the cache.
+"""
+
+import json
+import os
+
+import h5py
+import torch
+from PIL import Image
+from tqdm import tqdm
+from transformers import CLIPImageProcessor, CLIPVisionModel
+from omegaconf import OmegaConf
+
+from data.vqa_dataset import VQAv2Dataset
+
+
+def pre_extract_features(
+    config,
+    split: str,
+    device: str = "cuda",
+    batch_size: int = 64,
+) -> None:
+    """Run ViT-L/14 on all COCO images for a split and save features to HDF5.
+
+    Each image is saved as float16 with shape (257, 1024):
+      - 1 CLS token + 256 patch tokens (ViT-L/14 @ 224)
+      - dim = 1024
+
+    Args:
+        config:     OmegaConf config (data.* and model.image_encoder)
+        split:      "train" or "val"
+        device:     "cuda" or "cpu"
+        batch_size: images per forward pass (reduce if OOM)
+    """
+    cfg       = config.data
+    data_root = cfg.data_root
+    meta      = VQAv2Dataset.SPLIT_FILES[split]
+
+    img_dir    = os.path.join(data_root, cfg.coco_dir,    meta["img_dir"])
+    ann_path   = os.path.join(data_root, cfg.vqav2_dir,   meta["ann"])
+    cache_dir  = os.path.join(data_root, cfg.cache_dir)
+    cache_path = os.path.join(cache_dir, meta["cache"])
+    os.makedirs(cache_dir, exist_ok=True)
+
+    # All unique image_ids referenced in VQAv2 annotations
+    with open(ann_path) as f:
+        ann_data = json.load(f)
+    image_ids = sorted({ann["image_id"] for ann in ann_data["annotations"]})
+    print(f"[pre_extract/{split}] {len(image_ids):,} unique images → {cache_path}")
+
+    # Load CLIP vision model
+    model_name = config.model.image_encoder
+    print(f"Loading {model_name} ...")
+    processor  = CLIPImageProcessor.from_pretrained(model_name)
+    model      = CLIPVisionModel.from_pretrained(model_name).to(device).eval()
+    print(f"Model loaded on {device} ✅")
+
+    with h5py.File(cache_path, "a") as h5f:
+        existing   = set(h5f.keys())
+        to_process = [iid for iid in image_ids if str(iid) not in existing]
+        print(f"  Already cached: {len(existing):,} | Remaining: {len(to_process):,}")
+
+        for i in tqdm(range(0, len(to_process), batch_size), desc=f"Extracting {split}"):
+            ids    = to_process[i : i + batch_size]
+            imgs, valid_ids = [], []
+
+            for iid in ids:
+                p = os.path.join(img_dir, f"{meta['img_prefix']}{iid:012d}.jpg")
+                if not os.path.exists(p):
+                    continue
+                try:
+                    imgs.append(Image.open(p).convert("RGB"))
+                    valid_ids.append(iid)
+                except Exception:
+                    continue
+
+            if not imgs:
+                continue
+
+            inputs = processor(images=imgs, return_tensors="pt").to(device)
+            with torch.no_grad():
+                feats = model(**inputs).last_hidden_state  # (B, 257, 1024)
+                feats = feats.cpu().numpy().astype("float16")
+
+            for j, iid in enumerate(valid_ids):
+                h5f.create_dataset(
+                    str(iid), data=feats[j],
+                    compression="gzip", compression_opts=1,
+                )
+
+    print(f"✅ Done! Cache: {cache_path}")
+
+
+if __name__ == "__main__":
+    cfg = OmegaConf.create({
+        "data": {
+            "data_root": "/content/data",
+            "vqav2_dir": "vqav2", "coco_dir": "coco", "cache_dir": "cache",
+            "train_size": 50000, "val_size": 10000,
+            "image_size": 224, "seed": 42, "batch_size": 32,
+        },
+        "model": {"image_encoder": "openai/clip-vit-large-patch14", "query_dim": 768},
+    })
+    for s in ["train", "val"]:
+        pre_extract_features(cfg, s, device="cuda", batch_size=64)

--- a/data/vqa_dataset.py
+++ b/data/vqa_dataset.py
@@ -1,16 +1,56 @@
-"""VQA dataset loader for VQAv2."""
+"""VQAv2 Dataset — canonical merged version.
+
+Base: Sprint-2 VQAv2Dataset (Task 11+12), extended with:
+  - Answer normalisation helpers (used by evaluator)
+  - Soft-target answer score computation (_get_answer_scores)
+  - Optional pre-built answer-vocab loading from answer_list.json
+  - Graceful blank-image fallback instead of zero-tensor
+  - All output keys aligned with configs/contracts.py
+
+COCO 2014 filenames: COCO_{train,val}2014_000000XXXXXX.jpg
+
+Usage (config-object interface, primary):
+    from data.vqa_dataset import VQAv2Dataset, build_dataloader
+    loader = build_dataloader("train", config, use_cache=True)
+
+Usage (legacy alias):
+    from data.vqa_dataset import VQADataset, build_vqa_dataloader
+"""
 
 from __future__ import annotations
 
 import json
 import os
+import random
+from collections import Counter
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List, Optional
 
+import h5py
 import torch
 from PIL import Image
 from torch.utils.data import DataLoader, Dataset
 from torchvision import transforms
+from transformers import AutoTokenizer
+
+from configs.contracts import (
+    ANSWER_VOCAB_SIZE,
+    IMAGE_SIZE,
+    KEY_ANSWER_LABEL,
+    KEY_ANSWER_SCORES,
+    KEY_ANSWER_TEXT,
+    KEY_ANSWER_TYPE,
+    KEY_ANSWERS,
+    KEY_ATTENTION_MASK,
+    KEY_IMAGE_FEATURES,
+    KEY_IMAGE_IDS,
+    KEY_INPUT_IDS,
+    KEY_PIXEL_VALUES,
+    KEY_QUESTION_IDS,
+    KEY_QUESTION_TEXT,
+    MAX_QUESTION_LENGTH,
+    VQA_SCORE_DENOMINATOR,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -94,202 +134,417 @@ def normalize_answer(answer: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Dataset
+# Answer vocabulary builder
 # ---------------------------------------------------------------------------
 
 
-class VQADataset(Dataset):
-    """Dataset for VQAv2.
+def build_answer_vocab(annotation_file: str, top_k: int = ANSWER_VOCAB_SIZE) -> Dict[str, int]:
+    """Count answer frequencies from a VQAv2 annotations JSON; keep top_k.
+
+    Answers are normalised before counting so the vocab is canonical.
 
     Args:
-        question_file: Path to VQAv2 questions JSON.
-        annotation_file: Path to VQAv2 annotations JSON (optional for test split).
-        image_dir: Directory containing COCO images.
-        answer_list_file: Path to JSON file with list of answer vocab strings.
-        transform: Image transform; defaults to a standard resize/normalize.
-        max_question_length: Truncation length for questions.
-        is_train: Whether this is a training split (enables answer sampling).
+        annotation_file: Path to VQAv2 annotations JSON (train split recommended).
+        top_k: Vocabulary size (default ANSWER_VOCAB_SIZE = 3129).
+
+    Returns:
+        ``{normalised_answer: index}`` ordered by descending frequency.
+    """
+    with open(annotation_file) as f:
+        data = json.load(f)
+    counter: Counter = Counter()
+    for ann in data["annotations"]:
+        for a in ann["answers"]:
+            counter[normalize_answer(a["answer"])] += 1
+    return {ans: idx for idx, (ans, _) in enumerate(counter.most_common(top_k))}
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TRANSFORM = transforms.Compose([
+    transforms.Resize((IMAGE_SIZE, IMAGE_SIZE)),
+    transforms.ToTensor(),
+    transforms.Normalize(
+        mean=[0.48145466, 0.4578275, 0.40821073],
+        std=[0.26862954, 0.26130258, 0.27577711],
+    ),
+])
+
+
+class VQAv2Dataset(Dataset):
+    """VQAv2 dataset supporting HDF5 pre-extracted feature cache and raw COCO images.
+
+    Primary interface — takes a config object:
+
+        dataset = VQAv2Dataset("train", config, use_cache=True)
+
+    Config object must expose ``config.data.*`` with the keys defined in
+    :class:`configs.contracts.DataConfig` (Sprint-2 style).
+
+    Args:
+        split:     ``"train"`` or ``"val"``.
+        config:    Config object with a ``.data`` attribute (OmegaConf or similar).
+        use_cache: Load pre-extracted HDF5 features instead of raw images.
+                   Cache must be created first with ``scripts/pre_extract_features.py``.
     """
 
-    def __init__(
-        self,
-        question_file: str,
-        annotation_file: Optional[str],
-        image_dir: str,
-        answer_list_file: Optional[str] = None,
-        transform: Optional[Callable] = None,
-        max_question_length: int = 50,
-        is_train: bool = True,
-    ) -> None:
-        super().__init__()
-        self.image_dir = Path(image_dir)
-        self.max_question_length = max_question_length
-        self.is_train = is_train
+    #: Mapping from split name to file/directory metadata.
+    SPLIT_FILES = {
+        "train": {
+            "ann":        "v2_mscoco_train2014_annotations.json",
+            "ques":       "v2_OpenEnded_mscoco_train2014_questions.json",
+            "img_dir":    "train2014",
+            "img_prefix": "COCO_train2014_",
+            "cache":      "train_features.h5",
+        },
+        "val": {
+            "ann":        "v2_mscoco_val2014_annotations.json",
+            "ques":       "v2_OpenEnded_mscoco_val2014_questions.json",
+            "img_dir":    "val2014",
+            "img_prefix": "COCO_val2014_",
+            "cache":      "val_features.h5",
+        },
+    }
 
-        # Load questions
-        with open(question_file, "r") as f:
-            question_data = json.load(f)
-        self.questions: List[Dict] = question_data["questions"]
+    def __init__(self, split: str, config, use_cache: bool = True) -> None:
+        assert split in ("train", "val"), f"split must be 'train' or 'val', got '{split}'"
+        self.split = split
+        self.use_cache = use_cache
 
-        # Build question-id → question map
-        self._qid_to_question: Dict[int, Dict] = {
-            q["question_id"]: q for q in self.questions
+        cfg = config.data
+        data_root = cfg.data_root
+        meta = self.SPLIT_FILES[split]
+
+        ann_path  = os.path.join(data_root, cfg.vqav2_dir, meta["ann"])
+        ques_path = os.path.join(data_root, cfg.vqav2_dir, meta["ques"])
+        self.image_dir  = os.path.join(data_root, cfg.coco_dir, meta["img_dir"])
+        self.img_prefix = meta["img_prefix"]
+        self._img_size  = int(getattr(cfg, "image_size", IMAGE_SIZE))
+
+        # ── Load questions + annotations, merge into self.samples ────────────
+        with open(ann_path) as f:
+            ann_data = json.load(f)
+        with open(ques_path) as f:
+            ques_data = json.load(f)
+
+        qid2question = {q["question_id"]: q["question"] for q in ques_data["questions"]}
+        self.samples: List[Dict] = []
+        for ann in ann_data["annotations"]:
+            qid = ann["question_id"]
+            question = qid2question.get(qid, "")
+            if not question:
+                continue
+            raw_answers = [a["answer"] for a in ann["answers"]]
+            self.samples.append({
+                "question_id": qid,
+                "image_id":    ann["image_id"],
+                "question":    question,
+                "answers":     raw_answers,
+                "answer":      ann.get("multiple_choice_answer",
+                                       raw_answers[0] if raw_answers else ""),
+                "answer_type": ann.get("answer_type", "other"),
+            })
+
+        # ── Stratified subset selection ──────────────────────────────────────
+        subset_size = int(cfg.train_size if split == "train" else cfg.val_size)
+        seed = int(getattr(cfg, "seed", 42))
+        indices = VQAv2Dataset._stratified_indices(self.samples, subset_size, seed)
+        self.samples = [self.samples[i] for i in indices]
+
+        # ── Image transform ──────────────────────────────────────────────────
+        self.transform = transforms.Compose([
+            transforms.Resize((self._img_size, self._img_size)),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=[0.48145466, 0.4578275, 0.40821073],
+                std=[0.26862954, 0.26130258, 0.27577711],
+            ),
+        ])
+
+        # ── Answer vocabulary ────────────────────────────────────────────────
+        # Priority 1: pre-built answer_list file from config (if present)
+        # Priority 2: build dynamically from this split's annotation file
+        answer_list_path = getattr(cfg, "answer_list", None)
+        if answer_list_path and os.path.exists(str(answer_list_path)):
+            with open(answer_list_path) as f:
+                raw_vocab = json.load(f)
+            self.idx_to_answer: List[str] = [normalize_answer(a) for a in raw_vocab]
+            self.answer_to_idx: Dict[str, int] = {
+                a: i for i, a in enumerate(self.idx_to_answer)
+            }
+        else:
+            self.answer_to_idx = build_answer_vocab(ann_path, top_k=ANSWER_VOCAB_SIZE)
+            self.idx_to_answer = [""] * len(self.answer_to_idx)
+            for ans, idx in self.answer_to_idx.items():
+                self.idx_to_answer[idx] = ans
+
+        # ── HDF5 cache ───────────────────────────────────────────────────────
+        self._h5 = None
+        if use_cache:
+            self._h5_path = os.path.join(data_root, cfg.cache_dir, meta["cache"])
+            if not os.path.exists(self._h5_path):
+                raise FileNotFoundError(
+                    f"Cache not found: {self._h5_path}\n"
+                    "Run scripts/pre_extract_features.py first, or set use_cache=False."
+                )
+
+        print(f"[VQAv2Dataset/{split}] {len(self.samples):,} samples | "
+              f"vocab={len(self.answer_to_idx):,} | use_cache={use_cache}")
+
+    # ------------------------------------------------------------------
+    # Core Dataset interface
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> Dict:
+        s = self.samples[idx]
+
+        item: Dict = {
+            "question_id": s["question_id"],
+            "image_id":    s["image_id"],
+            "question":    s["question"],
+            KEY_ANSWERS:   s["answers"],        # List[str] — all 10 raw answers
+            KEY_ANSWER_TEXT: s["answer"],       # str       — most common answer
+            KEY_ANSWER_TYPE: s["answer_type"],  # str       — "yes/no"|"number"|"other"
         }
 
-        # Load annotations (ground-truth answers) if provided
-        self._annotations: Dict[int, Dict] = {}
-        if annotation_file and os.path.exists(annotation_file):
-            with open(annotation_file, "r") as f:
-                ann_data = json.load(f)
-            for ann in ann_data["annotations"]:
-                self._annotations[ann["question_id"]] = ann
-
-        # Load answer vocabulary
-        self.answer_to_idx: Dict[str, int] = {}
-        self.idx_to_answer: List[str] = []
-        if answer_list_file and os.path.exists(answer_list_file):
-            with open(answer_list_file, "r") as f:
-                answers = json.load(f)
-            self.idx_to_answer = [normalize_answer(a) for a in answers]
-            self.answer_to_idx = {a: i for i, a in enumerate(self.idx_to_answer)}
-
-        # Image transform
-        if transform is not None:
-            self.transform = transform
+        # ── Image / features ─────────────────────────────────────────────────
+        if self.use_cache:
+            if self._h5 is None:                        # lazy open (DataLoader fork-safe)
+                self._h5 = h5py.File(self._h5_path, "r")
+            item[KEY_IMAGE_FEATURES] = torch.from_numpy(
+                self._h5[str(s["image_id"])][()].astype("float32")
+            )
         else:
-            self.transform = transforms.Compose([
-                transforms.Resize((224, 224)),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.48145466, 0.4578275, 0.40821073],
-                    std=[0.26862954, 0.26130258, 0.27577711],
-                ),
-            ])
+            p = os.path.join(self.image_dir,
+                             f"{self.img_prefix}{s['image_id']:012d}.jpg")
+            if os.path.exists(p):
+                img = Image.open(p).convert("RGB")
+            else:
+                img = Image.new("RGB", (self._img_size, self._img_size), color=128)
+            item[KEY_PIXEL_VALUES] = self.transform(img)
+
+        # ── Soft-target answer scores + hard label ───────────────────────────
+        if self.answer_to_idx:
+            item[KEY_ANSWER_SCORES] = self._get_answer_scores(s["answers"])
+            label_idx = self.answer_to_idx.get(normalize_answer(s["answer"]), -1)
+            item[KEY_ANSWER_LABEL] = torch.tensor(label_idx, dtype=torch.long)
+
+        return item
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
-    def __len__(self) -> int:
-        return len(self.questions)
+    def _get_answer_scores(self, raw_answers: List[str]) -> torch.Tensor:
+        """Compute soft-target VQA score vector from raw answer strings.
 
-    def _image_filename(self, image_id: int) -> Path:
-        """Return the image file path for a given COCO image_id."""
-        filename = f"COCO_{'train' if self.is_train else 'val'}2014_{image_id:012d}.jpg"
-        path = self.image_dir / filename
-        if not path.exists():
-            # Fallback: bare id without split prefix
-            path = self.image_dir / f"{image_id:012d}.jpg"
-        return path
+        Score formula: ``min(count / VQA_SCORE_DENOMINATOR, 1.0)`` per answer.
 
-    def _get_answer_scores(self, question_id: int) -> torch.Tensor:
-        """Return a soft-target score vector over the answer vocabulary."""
+        Args:
+            raw_answers: List of up to 10 raw answer strings for one question.
+
+        Returns:
+            Float tensor of shape ``[ANSWER_VOCAB_SIZE]`` with values in ``[0, 1]``.
+        """
         scores = torch.zeros(len(self.answer_to_idx), dtype=torch.float)
-        if question_id not in self._annotations:
-            return scores
-        ann = self._annotations[question_id]
         answer_counts: Dict[str, int] = {}
-        for a in ann.get("answers", []):
-            norm = normalize_answer(a["answer"])
+        for ans in raw_answers:
+            norm = normalize_answer(ans)
             answer_counts[norm] = answer_counts.get(norm, 0) + 1
         for ans, count in answer_counts.items():
             if ans in self.answer_to_idx:
-                # VQA accuracy: min(count / 3, 1)
-                scores[self.answer_to_idx[ans]] = min(count / 3.0, 1.0)
+                scores[self.answer_to_idx[ans]] = min(
+                    count / VQA_SCORE_DENOMINATOR, 1.0
+                )
         return scores
 
-    # ------------------------------------------------------------------
-    # __getitem__
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _stratified_indices(
+        samples: List[Dict], subset_size: int, seed: int = 42
+    ) -> List[int]:
+        """Sample ``subset_size`` indices with stratification by ``answer_type``.
 
-    def __getitem__(self, idx: int) -> Dict:
-        question_info = self.questions[idx]
-        question_id = question_info["question_id"]
-        image_id = question_info["image_id"]
-        question_text = question_info["question"]
+        Each answer type gets a proportional share of the subset.  Remaining
+        slots (rounding differences) are filled randomly.
 
-        # Truncate question
-        words = question_text.split()
-        if len(words) > self.max_question_length:
-            question_text = " ".join(words[: self.max_question_length])
+        Args:
+            samples:     Full sample list with ``"answer_type"`` key.
+            subset_size: Desired number of samples.
+            seed:        Random seed for reproducibility.
 
-        # Load image
-        image_path = self._image_filename(image_id)
-        if image_path.exists():
-            image = Image.open(image_path).convert("RGB")
-        else:
-            # Return a blank image when file is not available (offline testing)
-            image = Image.new("RGB", (224, 224), color=128)
-        image = self.transform(image)
+        Returns:
+            List of integer indices into ``samples``.
+        """
+        rng = random.Random(seed)
+        type2idx: Dict[str, List[int]] = {}
+        for i, s in enumerate(samples):
+            type2idx.setdefault(s["answer_type"], []).append(i)
 
-        item = {
-            "question_id": question_id,
-            "image_id": image_id,
-            "image": image,
-            "question": question_text,
-        }
+        total = len(samples)
+        selected: List[int] = []
+        for indices in type2idx.values():
+            n = int(round(len(indices) / total * subset_size))
+            rng.shuffle(indices)
+            selected.extend(indices[:n])
 
-        # Add answer labels when annotations are available
-        if self._annotations:
-            ann = self._annotations.get(question_id, {})
-            answer_type = ann.get("answer_type", "other")
-            most_common = ann.get("multiple_choice_answer", "")
-            item["answer_type"] = answer_type
-            item["most_common_answer"] = normalize_answer(most_common)
-            if self.answer_to_idx:
-                item["answer_scores"] = self._get_answer_scores(question_id)
-                label = self.answer_to_idx.get(normalize_answer(most_common), -1)
-                item["answer_label"] = torch.tensor(label, dtype=torch.long)
+        if len(selected) > subset_size:
+            rng.shuffle(selected)
+            selected = selected[:subset_size]
+        elif len(selected) < subset_size:
+            remaining = list(set(range(total)) - set(selected))
+            rng.shuffle(remaining)
+            selected.extend(remaining[: subset_size - len(selected)])
 
-        return item
+        return selected
 
 
 # ---------------------------------------------------------------------------
-# DataLoader factory
+# Tokenizer (module-level singleton, DataLoader worker-safe)
 # ---------------------------------------------------------------------------
 
+_tokenizer = None
 
-def build_vqa_dataloader(
-    question_file: str,
-    annotation_file: Optional[str],
-    image_dir: str,
-    answer_list_file: Optional[str] = None,
-    transform: Optional[Callable] = None,
-    batch_size: int = 32,
-    num_workers: int = 4,
-    is_train: bool = True,
-    shuffle: Optional[bool] = None,
+
+def get_tokenizer(model_name: str = "bert-base-uncased") -> AutoTokenizer:
+    """Return a cached BERT tokenizer (loaded once per process)."""
+    global _tokenizer
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(model_name)
+    return _tokenizer
+
+
+# ---------------------------------------------------------------------------
+# collate_fn  — keys aligned with configs/contracts.py
+# ---------------------------------------------------------------------------
+
+def collate_fn(batch: List[Dict]) -> Dict:
+    """Collate a list of :meth:`VQAv2Dataset.__getitem__` dicts into a batch.
+
+    Key mapping (all names from contracts.KEY_*):
+        input_ids      — tokenized question ids      [B, MAX_QUESTION_LENGTH]
+        attention_mask — padding mask                [B, MAX_QUESTION_LENGTH]
+        question_text  — raw question strings        List[str]
+        question_ids   — VQAv2 question_id           List[int]
+        image_ids      — COCO image_id               List[int]
+        answer         — most common answer          List[str]
+        answers        — all 10 raw answers          List[List[str]]
+        answer_type    — answer type string          List[str]
+        pixel_values   — raw image tensor            [B, 3, H, W]   (use_cache=False)
+        image_features — pre-extracted features      [B, N, D]      (use_cache=True)
+        answer_scores  — soft-target VQA scores      [B, ANSWER_VOCAB_SIZE]
+        answer_label   — hard label index            [B]
+    """
+    tokenizer = get_tokenizer()
+    questions = [b["question"] for b in batch]
+    enc = tokenizer(
+        questions,
+        padding=True,
+        truncation=True,
+        max_length=MAX_QUESTION_LENGTH,
+        return_tensors="pt",
+    )
+
+    result: Dict = {
+        KEY_INPUT_IDS:      enc["input_ids"],
+        KEY_ATTENTION_MASK: enc["attention_mask"],
+        KEY_QUESTION_TEXT:  questions,
+        KEY_QUESTION_IDS:   [b["question_id"]     for b in batch],
+        KEY_IMAGE_IDS:      [b["image_id"]        for b in batch],
+        KEY_ANSWER_TEXT:    [b[KEY_ANSWER_TEXT]   for b in batch],
+        KEY_ANSWERS:        [b[KEY_ANSWERS]       for b in batch],
+        KEY_ANSWER_TYPE:    [b[KEY_ANSWER_TYPE]   for b in batch],
+    }
+
+    # Exactly one of image_features / pixel_values is present per batch
+    if KEY_IMAGE_FEATURES in batch[0]:
+        result[KEY_IMAGE_FEATURES] = torch.stack([b[KEY_IMAGE_FEATURES] for b in batch])
+    else:
+        result[KEY_PIXEL_VALUES] = torch.stack([b[KEY_PIXEL_VALUES] for b in batch])
+
+    # Optional: answer supervision tensors (absent when vocab not loaded)
+    if KEY_ANSWER_SCORES in batch[0]:
+        result[KEY_ANSWER_SCORES] = torch.stack([b[KEY_ANSWER_SCORES] for b in batch])
+    if KEY_ANSWER_LABEL in batch[0]:
+        result[KEY_ANSWER_LABEL] = torch.stack([b[KEY_ANSWER_LABEL] for b in batch])
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# DataLoader factory (primary)
+# ---------------------------------------------------------------------------
+
+def build_dataloader(
+    split: str,
+    config,
+    use_cache: bool = True,
 ) -> DataLoader:
-    """Convenience function to construct a :class:`VQADataset` DataLoader.
+    """Build a stratified DataLoader for a VQAv2 split.
 
     Args:
-        question_file: Path to the VQAv2 questions JSON file.
-        annotation_file: Path to the VQAv2 annotations JSON (``None`` for test split).
-        image_dir: Directory containing COCO images.
-        answer_list_file: Path to the answer-vocabulary JSON.
-        transform: Optional image transform.
-        batch_size: Batch size.
-        num_workers: Number of DataLoader worker processes.
-        is_train: Whether this split is used for training.
-        shuffle: Whether to shuffle the dataset; defaults to ``is_train``.
+        split:     ``"train"`` or ``"val"``.
+        config:    Config object with ``config.data.*`` attributes.
+        use_cache: Use pre-extracted HDF5 features (requires cache file).
 
     Returns:
-        A PyTorch :class:`~torch.utils.data.DataLoader`.
+        A :class:`torch.utils.data.DataLoader` with :func:`collate_fn` applied.
     """
-    dataset = VQADataset(
-        question_file=question_file,
-        annotation_file=annotation_file,
-        image_dir=image_dir,
-        answer_list_file=answer_list_file,
-        transform=transform,
-        is_train=is_train,
-    )
-    if shuffle is None:
-        shuffle = is_train
+    dataset = VQAv2Dataset(split, config, use_cache=use_cache)
     return DataLoader(
         dataset,
-        batch_size=batch_size,
-        shuffle=shuffle,
-        num_workers=num_workers,
+        batch_size=int(config.data.batch_size),
+        shuffle=(split == "train"),
+        num_workers=int(getattr(config.data, "num_workers", 4)),
+        collate_fn=collate_fn,
         pin_memory=True,
+        drop_last=(split == "train"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat aliases
+# ---------------------------------------------------------------------------
+
+#: Alias for users/scripts that import the original class name.
+VQADataset = VQAv2Dataset
+
+#: Alias kept for scripts that import ``build_vqa_dataloader``.
+build_vqa_dataloader = build_dataloader
+
+
+# ---------------------------------------------------------------------------
+# Quick smoke-test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.create({
+        "data": {
+            "data_root":  "/content/data",
+            "vqav2_dir":  "vqav2",
+            "coco_dir":   "coco",
+            "cache_dir":  "cache",
+            "train_size": 512,
+            "val_size":   128,
+            "image_size": IMAGE_SIZE,
+            "seed":       42,
+            "batch_size": 8,
+            "num_workers": 0,
+        },
+        "model": {
+            "image_encoder": "openai/clip-vit-large-patch14",
+        },
+    })
+
+    loader = build_dataloader("train", cfg, use_cache=False)
+    batch  = next(iter(loader))
+    print("input_ids:    ", batch[KEY_INPUT_IDS].shape)
+    print("pixel_values: ", batch[KEY_PIXEL_VALUES].shape)
+    print("question_ids: ", batch[KEY_QUESTION_IDS][:3])
+    print("answer_scores:", batch[KEY_ANSWER_SCORES].shape)


### PR DESCRIPTION
This pull request expands the data module to improve feature extraction and dataset handling, especially for Visual Question Answering (VQA) tasks. The main changes include adding a new script for pre-extracting image features using a CLIP vision model and broadening the data module's public API to expose more utilities and classes.

**New feature extraction script:**

* Added `pre_extract_features.py`, a standalone script for extracting and caching ViT-L/14 (CLIP) image features from COCO 2014 images. This script loads images referenced in VQAv2 annotations, processes them in batches using the CLIP model, and saves the features to HDF5 files. It supports resuming by skipping already-processed images and is configurable via OmegaConf.

**Enhancements to data module API:**

* Updated `data/__init__.py` to expose additional dataset utilities and classes, including `VQAv2Dataset`, `build_dataloader`, `build_answer_vocab`, `normalize_answer`, `get_tokenizer`, and `collate_fn`, making them available for import and use throughout the codebase.
* Maintained backward compatibility by keeping existing aliases (`VQADataset`, `build_vqa_dataloader`) in the public API.