### PR TITLE
Refactor configs, model factory and evaluator

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,12 +1,9 @@
 model:
-  # Tên model — đổi sang tên EXP tương ứng khi train
-  # blip2_vqa | mean_linear | concat_fusion | mlb_fusion | mfb_fusion
-  # | cross_attn_fusion | qformer_scratch | perceiver_resampler
   name: blip2_vqa
   blip2_model_name: Salesforce/blip2-opt-2.7b
   num_query_tokens: 32
-  vision_width: 1024           # ViT-L/14 (CLIP) output dim
-  text_dim: 768                # BERT-base CLS output dim — dùng cho EXP models
+  vision_width: 1024
+  text_dim: 768
   hidden_size: 768
   num_layers: 12
   num_heads: 12
@@ -14,27 +11,21 @@ model:
   dropout: 0.1
   max_answer_length: 10
   fusion_output_size: 1024
-  num_answers: 3129            # VQAv2 answer vocabulary size
+  num_answers: 3129
 
 data:
-  # ── Đường dẫn gốc — điều chỉnh cho môi trường của bạn ──────────────────
-  # Colab + Google Drive ví dụ:  data_root: /content/drive/MyDrive/VQAv2
-  # Local ví dụ:                data_root: data
-  data_root:    data
-  vqav2_dir:    raw            # {data_root}/raw/ chứa file JSON VQAv2
-  coco_dir:     raw            # {data_root}/raw/ chứa train2014/ val2014/
-  cache_dir:    features       # {data_root}/features/ chứa train_features.h5
-  # ── Answer vocab ─────────────────────────────────────────────────────────
-  answer_list:  data/raw/answer_list.json   # đường dẫn tuyệt đối hoặc tương đối
-  # ── Kích thước subset (stratified sampling) ──────────────────────────────
-  train_size:   443757         # VQAv2 train đầy đủ; giảm khi thử nghiệm
-  val_size:     214354         # VQAv2 val đầy đủ
-  seed:         42
-  # ── DataLoader ───────────────────────────────────────────────────────────
-  batch_size:   32             # dùng bởi build_dataloader
+  data_root: data
+  vqav2_dir: raw
+  coco_dir: raw
+  cache_dir: features
+  answer_list: data/raw/answer_list.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  4
+  image_size: 224
+  num_workers: 4
 
 training:
   output_dir: checkpoints/

--- a/configs/exp01.yaml
+++ b/configs/exp01.yaml
@@ -1,77 +1,57 @@
-# EXP-01: Mean Pooling + Linear (Baseline)
-# Trainable params: ~5.6M | Input: pooled CLS-only cache
-# Batch: 32 (T4) / 64 (A100) | Est. time: 2-3h on T4
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp01.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp01 \
-#       --run_name exp01_lan1_<ten>
-
 model:
   name: mean_linear
-  vision_width: 1024             # CLIP ViT-L/14 patch dim
-  text_dim: 768                  # BERT-base CLS dim
+  vision_width: 1024
+  text_dim: 768
   hidden_size: 768
   num_answers: 3129
   fusion_output_size: 1024
   dropout: 0.1
-  # Cac truong duoi khong dung boi EXP-01 nhung giu de tranh loi OmegaConf
   num_layers: 12
   num_heads: 12
   intermediate_size: 3072
   num_query_tokens: 32
 
 data:
-  # Cau truc thu muc:
-  #   {data_root}/cache/           <- file .h5
-  #   {data_root}/data/vqav2/      <- JSON VQAv2
-  #   {data_root}/data/coco/       <- anh COCO
-  #   {data_root}/data/ans2idx.json
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp01
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp01
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp01
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp01
+  num_epochs: 10
   eval_batch_size: 64
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
-  gradient_accumulation_steps: 1   # effective batch = 32
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  gradient_accumulation_steps: 1
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp01_lan1            # doi thanh exp01_lan1_<ten> truoc khi chay
+  project: blip2-vqa-experiment
+  run_name: exp01_lan1
   wandb_run_id: null

--- a/configs/exp02.yaml
+++ b/configs/exp02.yaml
@@ -1,20 +1,9 @@
-# EXP-02: Concat + MLP
-# Trainable params: ~7.2M | Input: pooled CLS-only cache
-# Batch: 32 (T4) / 64 (A100) | Est. time: 2.5-3.7h on T4
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp02.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp02 \
-#       --run_name exp02_lan1_<ten>
-
 model:
   name: concat_fusion
   vision_width: 1024
   text_dim: 768
   hidden_size: 768
-  fusion_output_size: 1024       # hidden dim cua MLP
+  fusion_output_size: 1024
   num_answers: 3129
   dropout: 0.1
   num_layers: 12
@@ -23,49 +12,46 @@ model:
   num_query_tokens: 32
 
 data:
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp02
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp02
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp02
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp02
+  num_epochs: 10
   eval_batch_size: 64
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
   gradient_accumulation_steps: 1
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp02_lan1
+  project: blip2-vqa-experiment
+  run_name: exp02_lan1
   wandb_run_id: null

--- a/configs/exp03.yaml
+++ b/configs/exp03.yaml
@@ -1,21 +1,9 @@
-# EXP-03: MLB — Multi-modal Low-rank Bilinear (Hadamard Product)
-# Paper: Kim et al., ICLR 2017
-# Trainable params: ~10.5M | Input: pooled CLS-only cache
-# Batch: 32 (T4) / 64 (A100) | Est. time: 3-4.7h on T4
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp03.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp03 \
-#       --run_name exp03_lan1_<ten>
-
 model:
   name: mlb_fusion
   vision_width: 1024
   text_dim: 768
   hidden_size: 768
-  fusion_output_size: 2048       # chieu cua khong gian Hadamard
+  fusion_output_size: 2048
   num_answers: 3129
   dropout: 0.1
   num_layers: 12
@@ -24,49 +12,46 @@ model:
   num_query_tokens: 32
 
 data:
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp03
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp03
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp03
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp03
+  num_epochs: 10
   eval_batch_size: 64
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
   gradient_accumulation_steps: 1
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp03_lan1
+  project: blip2-vqa-experiment
+  run_name: exp03_lan1
   wandb_run_id: null

--- a/configs/exp04.yaml
+++ b/configs/exp04.yaml
@@ -1,21 +1,9 @@
-# EXP-04: MFB — Multi-modal Factorized Bilinear
-# Paper: Zhou et al., ICCV 2017
-# Trainable params: ~17M | Input: pooled CLS-only cache
-# Batch: 32 (T4) / 64 (A100) | Est. time: 3.7-5.8h on T4
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp04.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp04 \
-#       --run_name exp04_lan1_<ten>
-
 model:
   name: mfb_fusion
   vision_width: 1024
   text_dim: 768
   hidden_size: 768
-  fusion_output_size: 1024       # d trong MFB: proj_dim = k * d = 5 * 1024 = 5120
+  fusion_output_size: 1024
   num_answers: 3129
   dropout: 0.1
   num_layers: 12
@@ -24,49 +12,46 @@ model:
   num_query_tokens: 32
 
 data:
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp04
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp04
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp04
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp04
+  num_epochs: 10
   eval_batch_size: 64
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
   gradient_accumulation_steps: 1
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp04_lan1
+  project: blip2-vqa-experiment
+  run_name: exp04_lan1
   wandb_run_id: null

--- a/configs/exp05.yaml
+++ b/configs/exp05.yaml
@@ -1,27 +1,10 @@
-# EXP-05: Query Cross-Attention Bridge
-# Trainable params: ~22M | Input: FULL patch tokens [B, 257, 1024]
-# Batch: 16 (T4, VRAM limit) / 32 (A100) | Est. time: 7.5-12h on T4
-#
-# LUU Y: EXP-05 can TOAN BO patch tokens — KHONG dung duoc CLS-only cache.
-#   Nen chay on-the-fly ViT inference hoac cache day du (63GB).
-#   Khuyen nghi: dung A100 cho EXP-05.
-#
-# T4: bat gradient_accumulation_steps=2 de giu effective batch=32
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp05.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp05 \
-#       --run_name exp05_lan1_<ten>
-
 model:
   name: cross_attn_fusion
-  vision_width: 1024             # CLIP ViT-L/14 patch dim
+  vision_width: 1024
   text_dim: 768
   hidden_size: 768
-  num_query_tokens: 32           # so learnable query tokens
-  num_layers: 3                  # so lop cross-attention
+  num_query_tokens: 32
+  num_layers: 3
   num_heads: 8
   intermediate_size: 3072
   fusion_output_size: 1024
@@ -29,49 +12,46 @@ model:
   dropout: 0.1
 
 data:
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   16               # T4: 16; A100: 32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 16
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp05
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp05
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp05
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp05
+  num_epochs: 10
   eval_batch_size: 32
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
-  gradient_accumulation_steps: 2  # T4: 2 -> effective batch=32; A100: 1
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  gradient_accumulation_steps: 2
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp05_lan1
+  project: blip2-vqa-experiment
+  run_name: exp05_lan1
   wandb_run_id: null

--- a/configs/exp06.yaml
+++ b/configs/exp06.yaml
@@ -1,85 +1,56 @@
-# EXP-06: Q-Former from Scratch
-#
-# Cách dùng trên Colab:
-#   python scripts/train.py --config configs/exp06.yaml
-#
-# Điều chỉnh bắt buộc:
-#   - data.data_root   → thư mục gốc chứa data trong Google Drive
-#   - data.answer_list → đường dẫn đến answer_list.json
-#
-# Cấu trúc thư mục dữ liệu mong đợi:
-#   {data_root}/{vqav2_dir}/v2_OpenEnded_mscoco_train2014_questions.json
-#   {data_root}/{vqav2_dir}/v2_mscoco_train2014_annotations.json
-#   {data_root}/{vqav2_dir}/v2_OpenEnded_mscoco_val2014_questions.json
-#   {data_root}/{vqav2_dir}/v2_mscoco_val2014_annotations.json
-#   {data_root}/{cache_dir}/train_features.h5     ← pre-extracted CLIP features
-#   {data_root}/{cache_dir}/val_features.h5
-#
-# Nếu chưa có HDF5 cache, chạy trước:
-#   python data/pre_extract_features.py --config configs/exp06.yaml
-
 model:
-  name: qformer_scratch          # EXP-06
-  # Q-Former hyperparameters
-  vision_width: 1024             # CLIP ViT-L/14 patch dim — phải khớp với cache
-  text_dim: 768                  # BERT-base CLS dim
-  hidden_size: 768               # chiều ẩn Q-Former (chuẩn BERT-base)
-  num_query_tokens: 32           # số learnable query tokens
-  num_layers: 12                 # số lớp Q-Former
-  num_heads: 12                  # số đầu attention
-  intermediate_size: 3072        # chiều FFN ẩn (768 × 4)
+  name: qformer_scratch
+  vision_width: 1024
+  text_dim: 768
+  hidden_size: 768
+  num_query_tokens: 32
+  num_layers: 12
+  num_heads: 12
+  intermediate_size: 3072
   dropout: 0.1
-  num_answers: 3129              # VQAv2 answer vocabulary size
+  num_answers: 3129
 
 data:
-  # ╔══════════════════════════════════════════════════════════════════╗
-  # ║  Colab + Google Drive: đổi data_root → path trong Drive          ║
-  # ║  Ví dụ: /content/drive/MyDrive/VQAv2                             ║
-  # ╚══════════════════════════════════════════════════════════════════╝
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2      # {data_root}/data/vqav2/ chua JSON files
-  coco_dir:     data/coco       # {data_root}/data/coco/ chua train2014/ val2014/
-  cache_dir:    cache           # {data_root}/cache/ chua *.h5 cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  # Kích thước subset — dùng toàn bộ VQAv2
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   32               # effective batch = 32 × gradient_accumulation_steps
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 32
   max_question_length: 50
-  image_size:   224
-  num_workers:  2                # Colab: 2 workers là đủ
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp06
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp06
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp06
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp06
+  num_epochs: 10
   eval_batch_size: 64
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000            # bước warmup (gradient steps)
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
-  gradient_accumulation_steps: 2 # effective batch_size = 64
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  gradient_accumulation_steps: 2
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp06_qformer_scratch
-  wandb_run_id: null        # để null khi train lần đầu; điền run ID cụ thể khi muốn resume cùng W&B run
+  project: blip2-vqa-experiment
+  run_name: exp06_qformer_scratch
+  wandb_run_id: null

--- a/configs/exp07.yaml
+++ b/configs/exp07.yaml
@@ -1,26 +1,11 @@
-# EXP-07: Perceiver Resampler (Flamingo-style)
-# Paper: Alayrac et al., NeurIPS 2022
-# Trainable params: ~58M | Input: FULL patch tokens [B, 257, 1024]
-# Batch: 12 (T4) / 32 (A100) | Est. time: 9-14h on T4
-#
-# LUU Y: EXP-07 can TOAN BO patch tokens — khong dung CLS-only cache.
-#   T4: chay batch=12, accum=3 -> effective batch=36
-#   Khuyen nghi: dung A100.
-#
-# Cach chay:
-#   python scripts/train.py --config configs/exp07.yaml \
-#       --data_root /content/drive/MyDrive/blip2_project/data \
-#       --answer_list /content/drive/MyDrive/blip2_project/data/ans2idx.json \
-#       --output_dir /content/drive/MyDrive/blip2_project/checkpoints/exp07 \
-#       --run_name exp07_lan1_<ten>
-
 model:
   name: perceiver_resampler
-  vision_width: 1024             # CLIP ViT-L/14 patch dim
+  vision_width: 1024
   text_dim: 768
   hidden_size: 768
-  num_query_tokens: 64           # M=64 latent vectors (khac exp05/06 dung 32)
-  num_layers: 4                  # so lop Perceiver
+  num_latents: 64
+  num_query_tokens: 64
+  num_layers: 4
   num_heads: 8
   intermediate_size: 3072
   fusion_output_size: 1024
@@ -28,49 +13,46 @@ model:
   dropout: 0.1
 
 data:
-  data_root:    /content/drive/MyDrive/blip2_project
-  vqav2_dir:    data/vqav2
-  coco_dir:     data/coco
-  cache_dir:    cache
-
-  answer_list:  /content/drive/MyDrive/blip2_project/data/ans2idx.json
-
-  train_size:   443757
-  val_size:     214354
-  seed:         42
-
-  batch_size:   12               # T4: 12; A100: 32
+  data_root: /content/drive/MyDrive/blip2_project
+  vqav2_dir: data/vqav2
+  coco_dir: data/coco
+  cache_dir: cache
+  answer_list: /content/drive/MyDrive/blip2_project/data/ans2idx.json
+  train_size: 443757
+  val_size: 214354
+  seed: 42
+  batch_size: 12
   max_question_length: 50
-  image_size:   224
-  num_workers:  2
+  image_size: 224
+  num_workers: 2
 
 training:
-  output_dir:  /content/drive/MyDrive/blip2_project/checkpoints/exp07
-  log_dir:     /content/drive/MyDrive/blip2_project/logs/exp07
-  num_epochs:  10
+  output_dir: /content/drive/MyDrive/blip2_project/checkpoints/exp07
+  log_dir: /content/drive/MyDrive/blip2_project/logs/exp07
+  num_epochs: 10
   eval_batch_size: 32
   learning_rate: 1.0e-4
-  weight_decay:  0.05
-  warmup_steps:  1000
+  weight_decay: 0.05
+  warmup_steps: 1000
   gradient_clip: 1.0
-  gradient_accumulation_steps: 3  # T4: 3 -> effective batch=36; A100: 1
-  save_every:  1
-  eval_every:  1
-  seed:        42
+  gradient_accumulation_steps: 3
+  save_every: 1
+  eval_every: 1
+  seed: 42
   mixed_precision: true
   resume_from: null
 
 optimizer:
-  name:  adamw
+  name: adamw
   betas: [0.9, 0.999]
-  eps:   1.0e-8
+  eps: 1.0e-8
 
 scheduler:
-  name:   cosine
+  name: cosine
   min_lr: 1.0e-6
 
 logging:
   use_wandb: true
-  project:   blip2-vqa-experiment
-  run_name:  exp07_lan1
+  project: blip2-vqa-experiment
+  run_name: exp07_lan1
   wandb_run_id: null

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,8 +1,18 @@
-from models.qformer import QFormer, QFormerConfig
-from models.blip2_vqa import BLIP2VQA
-from models.text_encoder import FrozenTextEncoder
+import torch.nn as nn
 
-# --- Fusion baselines (mỗi file tương ứng một thí nghiệm) ---
+from configs.contracts import (
+    ANSWER_VOCAB_SIZE,
+    MODEL_CONCAT_FUSION,
+    MODEL_CROSS_ATTN_FUSION,
+    MODEL_MEAN_LINEAR,
+    MODEL_MFB_FUSION,
+    MODEL_MLB_FUSION,
+    MODEL_PERCEIVER_RESAMPLER,
+    MODEL_QFORMER_SCRATCH,
+    QFORMER_HIDDEN_SIZE,
+    VISION_ENCODER_WIDTH,
+)
+from models.blip2_vqa import BLIP2VQA
 from models.exp01_mean_linear import MeanLinearFusion, build_mean_linear
 from models.exp02_concat_mlp import ConcatMLPFusion, build_concat_mlp
 from models.exp03_mlb import MLBFusion, build_mlb
@@ -10,99 +20,94 @@ from models.exp04_mfb import MFBFusion, build_mfb
 from models.exp05_cross_attn import CrossAttnFusion, build_cross_attn
 from models.exp06_qformer_scratch import QFormerScratch, build_qformer_scratch
 from models.exp07_perceiver_resampler import PerceiverResampler, build_perceiver_resampler
-
-from configs.contracts import (
-    ANSWER_VOCAB_SIZE,
-    MODEL_MEAN_LINEAR,
-    MODEL_CONCAT_FUSION,
-    MODEL_MLB_FUSION,
-    MODEL_MFB_FUSION,
-    MODEL_CROSS_ATTN_FUSION,
-    MODEL_QFORMER_SCRATCH,
-    MODEL_PERCEIVER_RESAMPLER,
-    QFORMER_HIDDEN_SIZE,
-    VISION_ENCODER_WIDTH,
-    VALID_MODEL_NAMES,
-)
-
-import torch.nn as nn
-
-# ---------------------------------------------------------------------------
-# Registry: ánh xạ tên model → factory function
-# ---------------------------------------------------------------------------
+from models.qformer import QFormer, QFormerConfig
+from models.text_encoder import FrozenTextEncoder
 
 _EXP_REGISTRY = {
-    MODEL_MEAN_LINEAR:       build_mean_linear,
-    MODEL_CONCAT_FUSION:     build_concat_mlp,
-    MODEL_MLB_FUSION:        build_mlb,
-    MODEL_MFB_FUSION:        build_mfb,
+    MODEL_MEAN_LINEAR: build_mean_linear,
+    MODEL_CONCAT_FUSION: build_concat_mlp,
+    MODEL_MLB_FUSION: build_mlb,
+    MODEL_MFB_FUSION: build_mfb,
     MODEL_CROSS_ATTN_FUSION: build_cross_attn,
-    MODEL_QFORMER_SCRATCH:   build_qformer_scratch,
+    MODEL_QFORMER_SCRATCH: build_qformer_scratch,
     MODEL_PERCEIVER_RESAMPLER: build_perceiver_resampler,
 }
 
 
+def _model_kwargs(config, name: str) -> dict:
+    model = config.model
+    kwargs = {
+        "visual_dim": getattr(model, "vision_width", VISION_ENCODER_WIDTH),
+        "text_dim": getattr(model, "text_dim", QFORMER_HIDDEN_SIZE),
+        "num_answers": getattr(model, "num_answers", ANSWER_VOCAB_SIZE),
+    }
+
+    if name in {MODEL_CONCAT_FUSION, MODEL_MLB_FUSION, MODEL_MFB_FUSION}:
+        fusion_dim_default = 2048 if name == MODEL_MLB_FUSION else 1024
+        kwargs.update(
+            fusion_dim=getattr(model, "fusion_output_size", fusion_dim_default),
+            dropout=getattr(model, "dropout", 0.1),
+        )
+    elif name == MODEL_CROSS_ATTN_FUSION:
+        kwargs.update(
+            hidden_dim=getattr(model, "hidden_size", QFORMER_HIDDEN_SIZE),
+            num_queries=getattr(model, "num_query_tokens", 32),
+            num_layers=getattr(model, "num_layers", 3),
+            num_heads=getattr(model, "num_heads", 12),
+            dropout=getattr(model, "dropout", 0.1),
+        )
+    elif name == MODEL_QFORMER_SCRATCH:
+        kwargs.update(
+            hidden_size=getattr(model, "hidden_size", QFORMER_HIDDEN_SIZE),
+            num_queries=getattr(model, "num_query_tokens", 32),
+            num_layers=getattr(model, "num_layers", 12),
+            num_heads=getattr(model, "num_heads", 12),
+            intermediate_size=getattr(model, "intermediate_size", 3072),
+            dropout=getattr(model, "dropout", 0.1),
+        )
+    elif name == MODEL_PERCEIVER_RESAMPLER:
+        kwargs.update(
+            hidden_dim=getattr(model, "hidden_size", QFORMER_HIDDEN_SIZE),
+            num_latents=getattr(
+                model, "num_latents", getattr(model, "num_query_tokens", 64)
+            ),
+            num_layers=getattr(model, "num_layers", 4),
+            num_heads=getattr(model, "num_heads", 12),
+            dropout=getattr(model, "dropout", 0.1),
+        )
+
+    return kwargs
+
+
 def build_model(config) -> nn.Module:
-    """Khởi tạo EXP fusion model từ config object.
-
-    Args:
-        config: OmegaConf config — phải có trường ``config.model.name``
-                khớp với một trong ``VALID_MODEL_NAMES``.
-
-    Returns:
-        Instance của EXP model tương ứng.
-
-    Raises:
-        ValueError: Nếu ``model.name`` không hợp lệ hoặc là ``blip2_vqa``
-                    (BLIP2VQA dùng pipeline riêng).
-    """
     name = config.model.name
     if name not in _EXP_REGISTRY:
         if name == "blip2_vqa":
-            raise ValueError(
-                "blip2_vqa dùng BLIP2VQA pipeline riêng — không dùng build_model()."
-            )
+            raise ValueError("blip2_vqa uses the BLIP2VQA pipeline.")
         raise ValueError(
-            f"Tên model '{name}' không hợp lệ. "
-            f"Các tên hợp lệ: {sorted(_EXP_REGISTRY.keys())}"
+            f"Unknown model '{name}'. Valid EXP models: {sorted(_EXP_REGISTRY.keys())}"
         )
-    factory = _EXP_REGISTRY[name]
-    return factory(
-        visual_dim=getattr(config.model, "vision_width", VISION_ENCODER_WIDTH),
-        text_dim=getattr(config.model, "text_dim", QFORMER_HIDDEN_SIZE),
-        num_answers=getattr(config.model, "num_answers", ANSWER_VOCAB_SIZE),
-    )
+    return _EXP_REGISTRY[name](**_model_kwargs(config, name))
 
 
 __all__ = [
-    # Kiến trúc nền
     "QFormer",
     "QFormerConfig",
     "BLIP2VQA",
-    # Text encoder (Phương án B)
     "FrozenTextEncoder",
-    # Factory tổng hợp
     "build_model",
-    "BLIP2VQA",
-    # EXP-01
     "MeanLinearFusion",
     "build_mean_linear",
-    # EXP-02
     "ConcatMLPFusion",
     "build_concat_mlp",
-    # EXP-03
     "MLBFusion",
     "build_mlb",
-    # EXP-04
     "MFBFusion",
     "build_mfb",
-    # EXP-05
     "CrossAttnFusion",
     "build_cross_attn",
-    # EXP-06
     "QFormerScratch",
     "build_qformer_scratch",
-    # EXP-07
     "PerceiverResampler",
     "build_perceiver_resampler",
 ]

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,19 +1,4 @@
-"""Đánh giá model VQA đã huấn luyện trên tập val hoặc test.
-
-Sử dụng
--------
-python scripts/evaluate.py \\
-    --config configs/default.yaml \\
-    --checkpoint checkpoints/best_model.pth \\
-    --split val \\
-    --output results/val_predictions.json
-
-Ghi chú pipeline
-----------------
-- Nếu ``model.name == "blip2_vqa"``: dùng BLIP2VQA legacy pipeline.
-- Ngược lại (EXP-01 → EXP-07): dùng EXP pipeline:
-    HDF5 image_features + FrozenTextEncoder (BERT) → fusion model → logits.
-"""
+"""Evaluate a trained VQA model on a validation or test split."""
 
 from __future__ import annotations
 
@@ -30,7 +15,6 @@ from omegaconf import OmegaConf
 from tqdm import tqdm
 
 from configs.contracts import (
-    KEY_ANSWER_TEXT,
     KEY_ATTENTION_MASK,
     KEY_IMAGE_FEATURES,
     KEY_INPUT_IDS,
@@ -41,7 +25,7 @@ from configs.contracts import (
 )
 from data.vqa_dataset import build_dataloader
 from evaluation.vqa_eval import VQAEvaluator
-from models import build_model, FrozenTextEncoder
+from models import FrozenTextEncoder, build_model
 from models.blip2_vqa import BLIP2VQA
 from utils.helpers import load_config, set_seed
 
@@ -53,19 +37,33 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def resolve_val_eval_paths(config) -> tuple[str | None, str | None]:
+    ann_file = getattr(config.data, "val_annotation_file", None)
+    q_file = getattr(config.data, "val_question_file", None)
+    if ann_file and q_file:
+        return str(ann_file), str(q_file)
+
+    data_root = getattr(config.data, "data_root", None)
+    vqav2_dir = getattr(config.data, "vqav2_dir", None)
+    if not data_root or not vqav2_dir:
+        return None, None
+
+    vqav2_root = Path(str(data_root)) / str(vqav2_dir)
+    return (
+        str(vqav2_root / "v2_mscoco_val2014_annotations.json"),
+        str(vqav2_root / "v2_OpenEnded_mscoco_val2014_questions.json"),
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Đánh giá model VQA trên tập val/test.",
+        description="Evaluate a VQA model on a validation or test split.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--config", type=str, default="configs/default.yaml")
-    parser.add_argument("--checkpoint", type=str, required=True,
-                        help="Đường dẫn checkpoint (.pth).")
-    parser.add_argument("--split", type=str, default="val",
-                        choices=["val", "test"],
-                        help="Split cần đánh giá.")
-    parser.add_argument("--output", type=str, default=None,
-                        help="Đường dẫn lưu file JSON dự đoán.")
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--split", type=str, default="val", choices=["val", "test"])
+    parser.add_argument("--output", type=str, default=None)
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--batch_size", type=int, default=None)
     return parser.parse_args()
@@ -80,29 +78,16 @@ def main() -> None:
     config = OmegaConf.create(cfg_dict)
 
     set_seed(int(getattr(config.training, "seed", 42)))
-
     device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
     logger.info("Device: %s", device)
 
     model_name = config.model.name
-
-    # ------------------------------------------------------------------
-    # Data loader
-    # ------------------------------------------------------------------
-    use_cache = (model_name != "blip2_vqa")
-    logger.info("Xây dựng DataLoader cho split '%s' (use_cache=%s) …", args.split, use_cache)
+    use_cache = model_name != "blip2_vqa"
     loader = build_dataloader(args.split, config, use_cache=use_cache)
-    logger.info("Số batch: %d", len(loader))
-
-    # Lấy ánh xạ index → câu trả lời từ vocab của dataset
+    logger.info("Batches: %d", len(loader))
     idx_to_answer: list = loader.dataset.idx_to_answer
 
-    # ------------------------------------------------------------------
-    # Khởi tạo model
-    # ------------------------------------------------------------------
-    logger.info("Tải model '%s' từ %s …", model_name, args.checkpoint)
     text_encoder = None
-
     if model_name == "blip2_vqa":
         model = BLIP2VQA(
             model_name=getattr(config.model, "blip2_model_name", "Salesforce/blip2-opt-2.7b"),
@@ -111,51 +96,45 @@ def main() -> None:
         )
     else:
         model = build_model(config)
-        text_encoder = FrozenTextEncoder()
-        text_encoder = text_encoder.to(device)
+        text_encoder = FrozenTextEncoder().to(device)
         text_encoder.eval()
 
     state = torch.load(args.checkpoint, map_location=device)
-    # Checkpoint có thể là dict với key KEY_MODEL_STATE hoặc raw state_dict
-    state_dict = state.get(KEY_MODEL_STATE, state)
-    model.load_state_dict(state_dict)
+    model.load_state_dict(state.get(KEY_MODEL_STATE, state))
     model = model.to(device)
     model.eval()
 
-    # ------------------------------------------------------------------
-    # Inference
-    # ------------------------------------------------------------------
     all_question_ids: list = []
     all_predicted_answers: list = []
 
     with torch.no_grad():
         for batch in tqdm(loader, desc="Evaluating"):
             if text_encoder is not None:
-                # EXP pipeline
                 visual_features = batch[KEY_IMAGE_FEATURES].to(device)
-                input_ids       = batch[KEY_INPUT_IDS].to(device)
-                attention_mask  = batch.get(KEY_ATTENTION_MASK)
+                input_ids = batch[KEY_INPUT_IDS].to(device)
+                attention_mask = batch.get(KEY_ATTENTION_MASK)
                 if attention_mask is not None:
                     attention_mask = attention_mask.to(device)
                 text_features = text_encoder(input_ids, attention_mask)
-                logits = model(visual_features, text_features)
-                pred_ids = logits.argmax(dim=-1).tolist()
+                pred_ids = model(visual_features, text_features).argmax(dim=-1).tolist()
             else:
-                # Legacy BLIP2VQA pipeline
                 pixel_values = batch[KEY_PIXEL_VALUES].to(device)
-                input_ids    = batch.get(KEY_INPUT_IDS)
+                input_ids = batch.get(KEY_INPUT_IDS)
                 if input_ids is not None:
                     input_ids = input_ids.to(device)
                 attention_mask = batch.get(KEY_ATTENTION_MASK)
                 if attention_mask is not None:
                     attention_mask = attention_mask.to(device)
-                out = model(pixel_values=pixel_values,
-                            input_ids=input_ids,
-                            attention_mask=attention_mask)
-                if KEY_LOGITS in out:
-                    pred_ids = out[KEY_LOGITS].argmax(dim=-1).tolist()
-                else:
-                    pred_ids = [0] * pixel_values.shape[0]
+                out = model(
+                    pixel_values=pixel_values,
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                )
+                pred_ids = (
+                    out[KEY_LOGITS].argmax(dim=-1).tolist()
+                    if KEY_LOGITS in out
+                    else [0] * pixel_values.shape[0]
+                )
 
             preds = [
                 idx_to_answer[i] if idx_to_answer and i < len(idx_to_answer) else str(i)
@@ -164,39 +143,29 @@ def main() -> None:
             all_question_ids.extend(batch[KEY_QUESTION_IDS])
             all_predicted_answers.extend(preds)
 
-    # ------------------------------------------------------------------
-    # Lưu predictions
-    # ------------------------------------------------------------------
+    predictions = [
+        {"question_id": int(qid), "answer": ans}
+        for qid, ans in zip(all_question_ids, all_predicted_answers)
+    ]
     if args.output:
         out_path = Path(args.output)
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        predictions = [
-            {"question_id": int(qid), "answer": ans}
-            for qid, ans in zip(all_question_ids, all_predicted_answers)
-        ]
         with open(out_path, "w") as f:
             json.dump(predictions, f, indent=2)
-        logger.info("Đã lưu dự đoán tại %s", out_path)
+        logger.info("Saved predictions to %s", out_path)
 
-    # ------------------------------------------------------------------
-    # Tính accuracy (chỉ cho split 'val' khi có annotation)
-    # ------------------------------------------------------------------
     if args.split == "val":
-        ann_file = getattr(config.data, "val_annotation_file", None)
-        q_file   = getattr(config.data, "val_question_file", None)
+        ann_file, q_file = resolve_val_eval_paths(config)
         if ann_file and q_file:
-            evaluator = VQAEvaluator(annotation_file=ann_file, question_file=q_file)
-            predictions = [
-                {"question_id": int(qid), "answer": ans}
-                for qid, ans in zip(all_question_ids, all_predicted_answers)
-            ]
-            results = evaluator.compute_accuracy(predictions)
-            logger.info("Kết quả đánh giá: %s", json.dumps(results, indent=2))
+            results = VQAEvaluator(
+                annotation_file=ann_file, question_file=q_file
+            ).compute_accuracy(predictions)
+            logger.info("Evaluation result: %s", json.dumps(results, indent=2))
             print(json.dumps(results, indent=2))
         else:
-            logger.info("Không tìm thấy annotation file; bỏ qua tính accuracy.")
+            logger.info("Validation annotations are not configured; skipping accuracy.")
     else:
-        logger.info("Split '%s': không có annotation; bỏ qua tính accuracy.", args.split)
+        logger.info("Split '%s' has no annotations; skipping accuracy.", args.split)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean up config YAMLs (remove inline comments, normalize spacing/values) and standardize data/training fields across default and exp{01..07}. Refactor models/__init__.py: reorganize imports, introduce _model_kwargs to centralize model argument preparation, simplify build_model with clearer errors, and tidy exported symbols. Revamp scripts/evaluate.py: rewrite docstring, add resolve_val_eval_paths, simplify arg parsing and loader/model setup, streamline checkpoint/state_dict handling, unify prediction saving, and clean up logging/messages. Changes are mostly structural and readability/robustness improvements.